### PR TITLE
Add ContentType, ContentField and ContentLink models

### DIFF
--- a/src/models/__tests__/content_field.test.ts
+++ b/src/models/__tests__/content_field.test.ts
@@ -1,0 +1,45 @@
+import { FieldType } from '../../model'
+import ContentField from '../content_field'
+
+describe('Content Type', () => {
+  it('allows the correct values and sets the right defaults', () => {
+    const contentField = new ContentField({
+      id: 'test',
+      name: 'Test',
+      type: FieldType.Symbol,
+    })
+
+    expect(contentField.id).toBe('test')
+    expect(contentField.name).toBe('Test')
+    expect(contentField.type).toBe(FieldType.Symbol)
+    expect(contentField.disabled).toBe(false)
+    expect(contentField.required).toBe(false)
+    expect(contentField.omitted).toBe(false)
+    expect(contentField.localized).toBe(false)
+    expect(contentField.validations.length).toBe(0)
+    expect(contentField.items).toBeNull()
+  })
+
+  it('has the correct options', () => {
+    const contentField = new ContentField({
+      id: 'backgroundColor',
+      name: 'Background Color',
+      type: FieldType.Symbol,
+      validations: [
+        {
+          in: [
+            'White',
+            'Off-White',
+            'Orange',
+          ],
+        },
+      ],
+    })
+
+    expect(contentField.options).toEqual([
+      'White',
+      'Off-White',
+      'Orange',
+    ])
+  })
+})

--- a/src/models/__tests__/content_link.test.ts
+++ b/src/models/__tests__/content_link.test.ts
@@ -1,0 +1,84 @@
+import { FieldType } from '../../model'
+import ContentLink, { ContentRelationship } from '../content_link'
+import ContentType from '../content_type'
+
+const imageTout = new ContentType({
+  id: 'imageTout',
+  name: 'Image Tout',
+  fields: [],
+})
+
+describe('Content Link', () => {
+  // it.skip('allows the correct values and sets the right defaults', () => {
+  //   const contentLink = new ContentLink({
+  //     id: 'test',
+  //     name: 'Test',
+  //   })
+
+  //   expect(contentLink.id).toBe('test')
+  //   expect(contentLink.name).toBe('Test')
+  //   expect(contentLink.type).toBe(FieldType.Symbol)
+  //   expect(contentLink.disabled).toBe(false)
+  //   expect(contentLink.required).toBe(false)
+  //   expect(contentLink.omitted).toBe(false)
+  //   expect(contentLink.localized).toBe(false)
+  //   expect(contentLink.validations.length).toBe(0)
+  //   expect(contentLink.items).toBeNull()
+  // })
+
+  it('toJSON works with hasMany', () => {
+    const contentLink = new ContentLink({
+      id: 'imageTouts',
+      name: 'Image Touts',
+      relationship: ContentRelationship.hasMany,
+      contentType: imageTout,
+    })
+
+    expect(contentLink.toJSON()).toEqual({
+      id: contentLink.id,
+      name: contentLink.name,
+      type: FieldType.Array,
+      omitted: false,
+      required: false,
+      items: {
+        linkType: 'Entry',
+        type: FieldType.Link,
+        validations: [
+          {
+            linkContentType: [imageTout.id],
+          },
+        ],
+      },
+      linkType: null,
+      validations: [],
+      disabled: false,
+      localized: false,
+    })
+  })
+
+  it('toJSON works with hasOne', () => {
+    const contentLink = new ContentLink({
+      id: 'imageTout',
+      name: 'Image Tout',
+      relationship: ContentRelationship.hasOne,
+      contentType: imageTout,
+    })
+
+    expect(contentLink.toJSON()).toEqual({
+      id: contentLink.id,
+      name: contentLink.name,
+      type: FieldType.Link,
+      linkType: 'Entry',
+      omitted: false,
+      required: false,
+      items: null,
+      validations: [
+        {
+          linkContentType: [imageTout.id],
+        },
+      ],
+      disabled: false,
+      localized: false,
+    })
+  })
+})

--- a/src/models/__tests__/content_type.test.ts
+++ b/src/models/__tests__/content_type.test.ts
@@ -1,0 +1,54 @@
+import { FieldType } from '../../model'
+import ContentField from '../content_field'
+import ContentType from '../content_type'
+
+const contentType = new ContentType({
+  id: 'hero',
+  name: 'Hero',
+  fields: [
+    new ContentField({
+      id: 'test',
+      name: 'Test',
+      type: FieldType.Symbol,
+    }),
+  ],
+})
+
+describe('Content Type', () => {
+  it('allows the correct values', () => {
+    expect(contentType.id).toBe('hero')
+    expect(contentType.name).toBe('Hero')
+    expect(contentType.description).toBeNull()
+    expect(contentType.displayField).toBeNull()
+    expect(contentType.fields.length).toBe(1)
+  })
+
+  it('getField works', () => {
+    expect(contentType.getField('test')).toBeInstanceOf(ContentField)
+    expect(contentType.getField('blah')).toBeNull()
+  })
+
+  it('toJSON returns correctly', () => {
+    expect(contentType.toJSON()).toEqual({
+      sys: {
+        id: contentType.id,
+        type: 'ContentType',
+      },
+      name: contentType.name,
+      description: contentType.description,
+      displayField: contentType.displayField,
+      fields: [
+        {
+          id: contentType.fields[0].id,
+          name: contentType.fields[0].name,
+          type: contentType.fields[0].type,
+          omitted: contentType.fields[0].omitted,
+          required: contentType.fields[0].required,
+          validations: contentType.fields[0].validations,
+          disabled: contentType.fields[0].disabled,
+          localized: contentType.fields[0].localized,
+        },
+      ],
+    })
+  })
+})

--- a/src/models/__tests__/content_type.test.ts
+++ b/src/models/__tests__/content_type.test.ts
@@ -44,6 +44,8 @@ describe('Content Type', () => {
           type: contentType.fields[0].type,
           omitted: contentType.fields[0].omitted,
           required: contentType.fields[0].required,
+          items: contentType.fields[0].items,
+          linkType: contentType.fields[0].linkType,
           validations: contentType.fields[0].validations,
           disabled: contentType.fields[0].disabled,
           localized: contentType.fields[0].localized,

--- a/src/models/content_field.ts
+++ b/src/models/content_field.ts
@@ -1,6 +1,6 @@
 import { FieldType, IContentFieldItems, IValidation, WidgetId } from '../model'
 
-interface IContentFieldAppearance {
+export interface IContentFieldAppearance {
   widgetId?: WidgetId
   settings?: {
     helpText?: string,
@@ -9,18 +9,84 @@ interface IContentFieldAppearance {
   }
 }
 
+export interface IContentFieldJSON {
+  id: string
+  name: string
+  type: string
+  localized: boolean
+  required: boolean
+  validations: IValidation[]
+  disabled: boolean
+  omitted: boolean
+}
+
+interface IContentField {
+  id: string,
+  name: string,
+  type: FieldType,
+  validations?: IValidation[],
+  localized?: boolean,
+  required?: boolean,
+  disabled?: boolean,
+  omitted?: boolean,
+  linkType?: 'Entry' | 'Asset',
+  items?: IContentFieldItems,
+  appearance?: IContentFieldAppearance,
+}
+
 export default class ContentField {
-  constructor(
-    public id: string,
-    public name: string,
-    public type: FieldType,
-    public validations?: IValidation[],
-    public localized?: boolean,
-    public required?: boolean,
-    public disabled?: boolean,
-    public omitted?: boolean,
-    public linkType?: 'Entry' | 'Asset',
-    public items?: IContentFieldItems,
-    public appearance?: IContentFieldAppearance,
-  ) { }
+  public id: string
+  public name: string
+  public type: FieldType
+  public validations: IValidation[]
+  public localized: boolean
+  public required: boolean
+  public disabled: boolean
+  public omitted: boolean
+  public linkType: 'Entry' | 'Asset' | null
+  public items: IContentFieldItems | null
+  public appearance: IContentFieldAppearance | null
+
+  constructor({
+    id,
+    name,
+    type,
+    appearance,
+    disabled,
+    items,
+    linkType,
+    localized,
+    omitted,
+    required,
+    validations,
+  }: IContentField) {
+    this.id = id
+    this.name = name
+    this.type = type
+    this.validations = validations || []
+    this.appearance = appearance || null
+    this.items = items || null
+    this.disabled = disabled || false
+    this.linkType = linkType || null
+    this.localized = localized || false
+    this.omitted = omitted || false
+    this.required = required || false
+  }
+
+  public get options() {
+    return this.validations.find((v) => v.in && v.in.length > 0)?.in
+  }
+
+  public toJSON(): IContentFieldJSON {
+    return {
+      id: this.id,
+      name: this.name,
+      omitted: this.omitted,
+      required: this.required,
+      validations: this.validations,
+      type: this.type.toString(),
+      localized: this.localized,
+      disabled: this.disabled,
+    }
+  }
 }

--- a/src/models/content_field.ts
+++ b/src/models/content_field.ts
@@ -1,0 +1,26 @@
+import { FieldType, IContentFieldItems, IValidation, WidgetId } from '../model'
+
+interface IContentFieldAppearance {
+  widgetId?: WidgetId
+  settings?: {
+    helpText?: string,
+    trueLabel?: string,
+    falseLabel?: string,
+  }
+}
+
+export default class ContentField {
+  constructor(
+    public id: string,
+    public name: string,
+    public type: FieldType,
+    public validations?: IValidation[],
+    public localized?: boolean,
+    public required?: boolean,
+    public disabled?: boolean,
+    public omitted?: boolean,
+    public linkType?: 'Entry' | 'Asset',
+    public items?: IContentFieldItems,
+    public appearance?: IContentFieldAppearance,
+  ) { }
+}

--- a/src/models/content_field.ts
+++ b/src/models/content_field.ts
@@ -14,7 +14,9 @@ export interface IContentFieldJSON {
   name: string
   type: string
   localized: boolean
+  linkType: 'Entry' | 'Asset' | null
   required: boolean
+  items: IContentFieldItems | null
   validations: IValidation[]
   disabled: boolean
   omitted: boolean
@@ -84,7 +86,9 @@ export default class ContentField {
       omitted: this.omitted,
       required: this.required,
       validations: this.validations,
+      linkType: this.linkType,
       type: this.type.toString(),
+      items: this.items,
       localized: this.localized,
       disabled: this.disabled,
     }

--- a/src/models/content_link.ts
+++ b/src/models/content_link.ts
@@ -1,0 +1,127 @@
+import { FieldType, IContentFieldItems, IValidation } from '../model'
+import { IContentFieldAppearance, IContentFieldJSON } from './content_field'
+import ContentType from './content_type'
+
+export enum ContentRelationship {
+  hasOne,
+  hasMany,
+}
+
+interface IContentLink {
+  id: string,
+  name: string,
+  contentType: ContentType,
+  relationship: ContentRelationship
+  validations?: IValidation[],
+  localized?: boolean,
+  required?: boolean,
+  disabled?: boolean,
+  omitted?: boolean,
+  linkType?: 'Entry' | 'Asset',
+  items?: IContentFieldItems,
+  appearance?: IContentFieldAppearance,
+}
+
+export default class ContentLink {
+  public id: string
+  public name: string
+  public required: boolean
+  public disabled: boolean
+  public localized: boolean
+  public omitted: boolean
+  public appearance: IContentFieldAppearance | null
+  public relationship: {
+    contentType: ContentType,
+    type: ContentRelationship,
+  }
+
+  // tslint:disable: variable-name
+  private _items: IContentFieldItems | null
+  private _validations: IValidation[]
+  private linkType: 'Entry' | 'Asset' | null
+  // tslint:enable: variable-name
+
+  constructor({
+    id,
+    name,
+    contentType,
+    relationship,
+    required,
+    omitted,
+    disabled,
+    localized,
+    validations,
+    items,
+    linkType,
+    appearance,
+  }: IContentLink) {
+    this.id = id
+    this.name = name
+    this.required = required || false
+    this.omitted = omitted || false
+    this.disabled = disabled || false
+    this.localized = localized || false
+    this._validations = validations || []
+    this.appearance = appearance || null
+    this._items = items || null
+    this.linkType = linkType || 'Entry'
+    this.relationship = {
+      contentType,
+      type: relationship,
+    }
+  }
+
+  public get validations(): IValidation[] {
+    if (this.isArray) { return this._validations }
+
+    return this._validations.concat([
+      {
+        linkContentType: [this.relationship.contentType.id],
+      },
+    ])
+  }
+
+  public get type(): FieldType {
+    switch (this.relationship.type) {
+      case ContentRelationship.hasMany:
+        return FieldType.Array
+      case ContentRelationship.hasOne:
+        return FieldType.Link
+      default:
+        return this.relationship.type as never
+    }
+  }
+
+  public get items(): IContentFieldItems | null {
+    if (!this.isArray) { return null }
+
+    return Object.assign<object, IContentFieldItems>(this._items || {}, {
+      linkType: this.linkType || 'Entry',
+      type: FieldType.Link,
+      validations: [
+        {
+          linkContentType: [this.relationship.contentType.id],
+        },
+      ],
+    })
+  }
+
+  public toJSON(): IContentFieldJSON {
+    return {
+      id: this.id,
+      disabled: this.disabled,
+      localized: this.localized,
+      name: this.name,
+      omitted: this.omitted,
+      required: this.required,
+      linkType: this.isArray ? null : this.linkType,
+      items: this.items,
+      type: this.type,
+      validations: this.validations,
+    }
+  }
+
+  private get isArray(): boolean {
+    return this.type === FieldType.Array
+  }
+}

--- a/src/models/content_type.ts
+++ b/src/models/content_type.ts
@@ -1,0 +1,11 @@
+import ContentField from './content_field'
+
+export default class ContentType {
+  constructor(
+    public id: string,
+    public description: string | null,
+    public displayField: string | null,
+    public fields: ContentField[],
+    public name: string,
+  ) { }
+}

--- a/src/models/content_type.ts
+++ b/src/models/content_type.ts
@@ -1,11 +1,61 @@
-import ContentField from './content_field'
+import ContentField, { IContentFieldJSON } from './content_field'
+
+interface IContentType {
+  id: string
+  name: string
+  fields: ContentField[]
+  description?: string
+  displayField?: string
+}
+
+interface IContentTypeJSON {
+  sys: {
+    id: string
+    type: 'ContentType',
+  }
+  displayField: string | null
+  name: string
+  description: string | null
+  fields: IContentFieldJSON[]
+}
 
 export default class ContentType {
-  constructor(
-    public id: string,
-    public description: string | null,
-    public displayField: string | null,
-    public fields: ContentField[],
-    public name: string,
-  ) { }
+  public id: string
+  public name: string
+  public description: string | null
+  public displayField: string | null
+  public fields: ContentField[]
+
+  constructor({
+    id,
+    fields,
+    name,
+    description,
+    displayField,
+  }: IContentType) {
+    this.id = id
+    this.name = name
+    this.fields = fields
+    this.description = description || null
+    this.displayField = displayField || null
+  }
+
+  public getField(fieldId: string): ContentField | null {
+    const field = this.fields.find((f) => f.id === fieldId)
+
+    return field || null
+  }
+
+  public toJSON(): IContentTypeJSON {
+    return {
+      sys: {
+        id: this.id,
+        type: 'ContentType',
+      },
+      description: this.description,
+      displayField: this.displayField,
+      fields: this.fields.map((f) => f.toJSON()),
+      name: this.name,
+    }
+  }
 }

--- a/src/modify.ts
+++ b/src/modify.ts
@@ -5,7 +5,7 @@ import {
   isSimpleDiff,
 } from './diff'
 import { IContentType, IField } from './model'
-import { IContext } from './runners'
+import { IContext } from './runners/index'
 import { dump } from './utils/object'
 import { camelCase } from './utils/string'
 
@@ -56,7 +56,7 @@ ${colorize(fieldsDiff, { color: false })} */
     { field: IField; diff: DiffObj<IField> } | null
   >()
 
-  let fromFieldIndex = 0
+  // let fromFieldIndex = 0
   let toFieldIndex = 0
 
   fieldsDiff.forEach((item) => {
@@ -80,7 +80,7 @@ ${colorize(fieldsDiff, { color: false })} */
             'Diff produced a "-" with a diff obj:\n' + JSON.stringify(item),
           )
         }
-        fromFieldIndex++
+        // fromFieldIndex++
         break
       case '~':
         if (val && isDiffObj(val)) {
@@ -93,11 +93,11 @@ ${colorize(fieldsDiff, { color: false })} */
             'Diff produced a "~" with a non-diff obj:\n' + JSON.stringify(item),
           )
         }
-        fromFieldIndex++
+        // fromFieldIndex++
         toFieldIndex++
         break
       default:
-        fromFieldIndex++
+        // fromFieldIndex++
         toFieldIndex++
 
         break

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "target": "ES2015",
     "declaration": true,
     "outDir": "dist",
     "noImplicitAny": true,


### PR DESCRIPTION
These models will allow building classes around your data models really easily, then you can use these inside of your program. I'm going to extend this library to pull all of your data models out, convert them to JSON and then diff them against Contentful or an exported version of contentful